### PR TITLE
fix: concat buffers as buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = async (source, options) => {
   let res, type
   for await (const chunk of source) {
     if (!res) {
-      type = options.type || typeof chunk === 'string' ? 'string' : 'buffer'
+      type = options.type || (typeof chunk === 'string' ? 'string' : 'buffer')
       res = TypeDefault[type]()
     }
 

--- a/test.mjs
+++ b/test.mjs
@@ -55,3 +55,9 @@ test('should throw for invalid type', async t => {
   const err = await t.throwsAsync(concat(input, { type: 'donkey' }))
   t.is(err.message, 'invalid type "donkey"')
 })
+
+test('should concat buffers as buffers', async t => {
+  const input = [Buffer.from('a0', 'hex')]
+  const output = await concat(input, { type: 'buffer' })
+  t.is(output.toString('hex'), 'a0')
+})


### PR DESCRIPTION
The missing parentheses meant that buffers were being concatenated as strings if you passed `{ type: 'buffer' }` as options.